### PR TITLE
fix: fix broken styles

### DIFF
--- a/pages/main/style.css
+++ b/pages/main/style.css
@@ -541,7 +541,7 @@ footer{
     display: none;
   }
   .backstage_block{
-    margin-top: 684px;
+    margin-top: 127px;
   }
   .backstage{
     width: 940px;
@@ -615,11 +615,11 @@ footer{
     height: 40px;
   }
   .strelitzia{
-    top: 2167px;
+    top: 2098px;
     transform: scale(0.655) translate(96px, 72px);
   }
   .palm{
-    top: 1982px;
+    top: 1914px;
     transform: scale(0.44) translate(-186px, 292px);
   }
   .pnf_menu{
@@ -687,7 +687,7 @@ footer{
     display: none;
   }
   .green_leaf{
-    top: 4019px;
+    top: 3954px;
     transform: scale(0.9) translate(14px, 13px);
   }
 }


### PR DESCRIPTION
1. Task: https://github.com/rolling-scopes-school/tasks/tree/master/stage1/stream2/online-zoo#неделя-2
2. Screenshot: 
![image](https://user-images.githubusercontent.com/52948556/193243050-b9bebd30-23f8-4981-a8c3-27158d957fb5.png)
3. Deploy: https://vkuth.github.io/rsschool-cv/pages/main/ 
4. Done 30.09.2022 / deadline 04.10.2022
5. Score:
1.(max-width: 1600px) или (max-width: 1599px) - Переход между состояниями фиксированной колонки и отзывчивой.
    -- Опционально (max-width: 1599px) или (max-width: 1440px) или (max-width: 1280px) или (max-width: 1220px)
2. (max-width: 1000px) - Изменение расположения кнопок врпаво/влево в блоке Pets. Обратите внимание, что карточки могут быть другие при изменеии ширины экрана, последовательность карточек (названия, картинки) - роли не играют. Изменение количества отзывов в блоке Testimonials, при этом сам текст в отзыве роли не играет, важен только размер.
    -- Опционально (max-width: 999px) или (max-width: 980px) или (max-width: 768px)
3. (max-width: 640px) - Замена меню в хедере на бургер меню. Хедер становится фиксированным. Потеря или преобразование некоторых элементов, и изменение расположения в блоках The backstage, Pick and feed a friend. Изменение количества, размера и отступов карточек животных в блоке Pets. Изменение расположения отзывов в блоке Testimonials.
-- Опционально (max-width: 639px) или (max-width: 600px)
4. (max-width: 320px) - Потеря или преобразование некоторых элементов, и изменение расположения в блоках The backstage, Pick and feed a friend. Изменение количества, размера и отступов карточек животных в блоке Pets. Изменение расположения отзывов в блоке Testimonials.